### PR TITLE
Correct typo and broken url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I wanted to try something with the Steam Web API and I was just bored :P
 
 ## Usage
 1. Clone this repo, open it in Visual Studio.
-2. In SteamGamePicker.cs change the `SteamWebAPIKey` varialbe to your [Steam Web API Key](http://steamcommunity.com/dev/registerkey).
+2. In SteamGamePicker.cs change the `SteamWebAPIKey` variable to your [Steam Web API Key](https://steamcommunity.com/dev/apikey).
 3. Run/Build
 4. Enter your SteamID in the corresponding textbox, choose your playtime filter.
 5. Click `Get Games` to fetch the list.


### PR DESCRIPTION
The url should be to the apikey page, not register key